### PR TITLE
Don't put the article link in the Disqus title

### DIFF
--- a/templates/disqus_comments.html
+++ b/templates/disqus_comments.html
@@ -2,7 +2,7 @@
 <script type="text/javascript">
     var disqus_shortname = '^disqus_shortname^';
     var disqus_identifier = '^article_id^';
-    var disqus_title = '^article_headline^';
+    var disqus_title = '^article_headline_nolink^';
     var disqus_url = '^article_permalink^';
 
     (function() {


### PR DESCRIPTION
Use article_headline_nolink instead of article_headline to pass just the article title text to Disqus without the wrapping anchor tag.